### PR TITLE
Add support for filtering on XS2A list financial institutions call

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 * Add support for periodic and bulk payments
 * Raise exception when a DateTime cannot be parsed from the response
+* Add support for filtering on XS2A list financial institutions call
+* Fix incorrect field types for financial institution
 
 ## 0.4.0
 

--- a/lib/ibanity/api/xs2a/financial_institution.ex
+++ b/lib/ibanity/api/xs2a/financial_institution.ex
@@ -190,10 +190,10 @@ defmodule Ibanity.Xs2a.FinancialInstitution do
       bulk_payments_enabled: {~w(attributes bulkPaymentsEnabled), :boolean},
       payments_enabled: {~w(attributes paymentsEnabled), :boolean},
       periodic_payments_enabled: {~w(attributes periodicPaymentsEnabled), :boolean},
-      bulk_payments_product_types: {~w(attributes bulkPaymentsProductTypes), :struct},
-      payments_product_types: {~w(attributes paymentsProductTypes), :struct},
-      periodic_payments_product_types: {~w(attributes periodicPaymentsProductTypes), :struct},
-      authorization_models: {~w(attributes authorizationModels), :struct}
+      bulk_payments_product_types: {~w(attributes bulkPaymentsProductTypes), :string},
+      payments_product_types: {~w(attributes paymentsProductTypes), :string},
+      periodic_payments_product_types: {~w(attributes periodicPaymentsProductTypes), :string},
+      authorization_models: {~w(attributes authorizationModels), :string}
     ]
   end
 end

--- a/lib/ibanity/util/query_params_util.ex
+++ b/lib/ibanity/util/query_params_util.ex
@@ -1,0 +1,57 @@
+defmodule Ibanity.QueryParamsUtil do
+  @moduledoc false
+
+  def encode_query([]), do: ""
+
+  def encode_query(query_params) do
+    IO.iodata_to_binary(encode_pair("", query_params))
+  end
+
+  # covers maps
+  defp encode_pair(parent_field, %{} = map) do
+    encode_kv(map, parent_field)
+  end
+
+  # covers keyword lists
+  defp encode_pair(parent_field, list) when is_list(list) and is_tuple(hd(list)) do
+    encode_kv(Enum.uniq_by(list, &elem(&1, 0)), parent_field)
+  end
+
+  # covers nil
+  defp encode_pair(field, nil) do
+    [field, ?=]
+  end
+
+  # encoder fallback
+  defp encode_pair(field, value) do
+    [field, ?= | encode_field(value)]
+  end
+
+  defp encode_kv(kv, parent_field) do
+    mapper = fn
+      {_, value} when value in [%{}, []] ->
+        []
+
+      {field, value} ->
+        field =
+          if parent_field == "" do
+            encode_field(field)
+          else
+            parent_field <> "[" <> encode_field(field) <> "]"
+          end
+
+        [?&, encode_pair(field, value)]
+    end
+
+    kv
+    |> Enum.flat_map(mapper)
+    |> prune()
+  end
+
+  defp encode_field(item) do
+    item |> to_string |> URI.encode_www_form()
+  end
+
+  defp prune([?& | t]), do: t
+  defp prune([]), do: []
+end

--- a/lib/ibanity/util/query_params_util.ex
+++ b/lib/ibanity/util/query_params_util.ex
@@ -1,3 +1,7 @@
+#
+# Credit: code adapted from the function `Plug.Conn.Query.encode/2`
+# from the `elixir-plug` library.
+#
 defmodule Ibanity.QueryParamsUtil do
   @moduledoc false
 

--- a/lib/ibanity/util/uri_util.ex
+++ b/lib/ibanity/util/uri_util.ex
@@ -1,7 +1,7 @@
 defmodule Ibanity.UriUtil do
   @moduledoc false
 
-  alias Ibanity.{Configuration, Request}
+  alias Ibanity.{Configuration, QueryParamsUtil, Request}
 
   @ids_matcher ~r/\{(\w+)\}/
 
@@ -10,8 +10,8 @@ defmodule Ibanity.UriUtil do
          {:ok, uri} <- replace_ids(uri, request.resource_ids) do
       encoded_params =
         request
-        |> create_query_params
-        |> Plug.Conn.Query.encode()
+        |> create_query_params()
+        |> QueryParamsUtil.encode_query()
 
       res = if encoded_params == "", do: uri, else: uri <> "?" <> encoded_params
 

--- a/lib/ibanity/util/uri_util.ex
+++ b/lib/ibanity/util/uri_util.ex
@@ -11,7 +11,7 @@ defmodule Ibanity.UriUtil do
       encoded_params =
         request
         |> create_query_params
-        |> URI.encode_query()
+        |> Plug.Conn.Query.encode()
 
       res = if encoded_params == "", do: uri, else: uri <> "?" <> encoded_params
 

--- a/test/lib/deserialization/xs2a/financial_institution_test.exs
+++ b/test/lib/deserialization/xs2a/financial_institution_test.exs
@@ -12,7 +12,12 @@ defmodule Ibanity.Xs2a.FinancialInstitution.DeserializationTest do
       "id" => "01faf09c-038d-43f3-8e0c-d0aaf3e0e176",
       "attributes" => %{
         "sandbox" => true,
-        "name" => "ABN AMRO HOARE GOVETT CORPORATE FINANCE LTD. 7"
+        "name" => "ABN AMRO HOARE GOVETT CORPORATE FINANCE LTD. 7",
+        "maxRequestedAccountReferences" => 3,
+        "minRequestedAccountReferences" => 1,
+        "requiresCredentialStorage" => false,
+        "paymentsProductTypes" => ["sepaCreditTransfer"],
+        "authorizationModels" => ["detailed", "financialInstitutionOffered"]
       }
     }
 
@@ -22,6 +27,11 @@ defmodule Ibanity.Xs2a.FinancialInstitution.DeserializationTest do
       id: "01faf09c-038d-43f3-8e0c-d0aaf3e0e176",
       sandbox: true,
       name: "ABN AMRO HOARE GOVETT CORPORATE FINANCE LTD. 7",
+      max_requested_account_references: 3,
+      min_requested_account_references: 1,
+      requires_credential_storage: false,
+      payments_product_types: ["sepaCreditTransfer"],
+      authorization_models: ["detailed", "financialInstitutionOffered"],
       self_link:
         "https://api.ibanity.com/financial-institutions/01faf09c-038d-43f3-8e0c-d0aaf3e0e176"
     }

--- a/test/lib/http_request_test.exs
+++ b/test/lib/http_request_test.exs
@@ -55,5 +55,30 @@ defmodule Ibanity.HttpRequestTest do
                  "before=27e718a7-af87-479f-bf78-b05027080188" <>
                  "&" <> "after=a6299d4d-eb81-4dfb-bb1b-b727000b2621"
     end
+
+    test "specifies country filter" do
+      {:ok, res} =
+        %Request{}
+        |> Request.query_params(filter: %{ country: "BE" })
+        |> HttpRequest.build(:get, @api_schema_path)
+
+      assert res.uri == "https://api.ibanity.com/customer/accounts" <>
+                          "?filter[country]=BE"
+    end
+
+    test "specifies name filter" do
+      filter = %{
+        name: %{
+          contains: "Jack"
+        }
+      }
+      {:ok, res} =
+        %Request{}
+        |> Request.query_params(filter: filter)
+        |> HttpRequest.build(:get, @api_schema_path)
+
+      assert res.uri == "https://api.ibanity.com/customer/accounts" <>
+                          "?filter[name][contains]=Jack"
+    end
   end
 end

--- a/test/lib/query_params_util_test.exs
+++ b/test/lib/query_params_util_test.exs
@@ -1,0 +1,40 @@
+defmodule Ibanity.QueryParamsUtilTest do
+  use ExUnit.Case
+  alias Ibanity.{QueryParamsUtil}
+
+  describe ".encode_query" do
+    test "no query params" do
+      res = QueryParamsUtil.encode_query([])
+
+      assert res == ""
+    end
+
+    test "simple params" do
+      res = QueryParamsUtil.encode_query([limit: 10])
+
+      assert res == "limit=10"
+    end
+
+    test "multiple params" do
+      res = QueryParamsUtil.encode_query([limit: 10, before: "cursor"])
+
+      assert res == "limit=10&before=cursor"
+    end
+
+    test "nested params" do
+      query_params = [
+        filter: %{
+          name: %{
+            eq: "Einstein"
+          },
+          country: %{
+            eq: "DE"
+          }
+        }
+      ]
+      res = QueryParamsUtil.encode_query(query_params)
+
+      assert res == "filter[country][eq]=DE&filter[name][eq]=Einstein"
+    end
+  end
+end

--- a/test/lib/query_params_util_test.exs
+++ b/test/lib/query_params_util_test.exs
@@ -1,8 +1,8 @@
 defmodule Ibanity.QueryParamsUtilTest do
   use ExUnit.Case
-  alias Ibanity.{QueryParamsUtil}
+  alias Ibanity.QueryParamsUtil
 
-  describe ".encode_query" do
+  describe "encode_query/1" do
     test "no query params" do
       res = QueryParamsUtil.encode_query([])
 


### PR DESCRIPTION
- Fix: Correct Financial Institution key_mapping, some fields were tagged as `:struct`, but are actually `:string`
- Handle nested maps for query params:
Example filter on "List financial institutions":
```
%{
  filter: %{
    name: %{
      contains: "Turing"
    }
  }
}
```

`URI.encode_query/1` cannot convert this to query params.

