### PR TITLE
Replace Mix.env/0 usage by config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,7 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
-import_config "#{Mix.env}.exs"
+config :ibanity, env: config_env()
+
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ibanity, :applications,
   default: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ibanity, :applications, [
   default: []

--- a/lib/ibanity/configuration.ex
+++ b/lib/ibanity/configuration.ex
@@ -77,7 +77,7 @@ defmodule Ibanity.Configuration do
     |> URI.parse()
     |> URI.merge("/#{product}")
     |> to_string()
-    |> ApiSchema.fetch(default_app_options(), Mix.env())
+    |> ApiSchema.fetch(default_app_options(), Application.get_env(:ibanity, :env))
   end
 
   def default_app_options, do: Agent.get(__MODULE__, & &1.applications_options[:default])


### PR DESCRIPTION
Mix is a build tool and should not be a runtime dependency.
As it turns out, we don't even include it in our app build since we are using elixir releases.
This means in the current state of things we **cannot use** the ibanity library because the call to `Mix.env()` makes our app fail in the startup phase.

The mechanism I propose to replace the Mix.env call is to use a config. It's the way it's done by many elixir libraries.