### PR TITLE
Fix partly broken authorization header

### DIFF
--- a/lib/ibanity/http_request.ex
+++ b/lib/ibanity/http_request.ex
@@ -78,7 +78,7 @@ defmodule Ibanity.HttpRequest do
     token = request.customer_access_token || request.token
 
     if token do
-      Keyword.put(headers, :Authorization, "Bearer #{request.token}")
+      Keyword.put(headers, :Authorization, "Bearer #{token}")
     else
       headers
     end


### PR DESCRIPTION
XS2A requests are broken, if request has token stored in `customer_access_token`, instead of `token`, resulting in an authorization header `"Bearer "` instead of `"Bearer TOKEN"`